### PR TITLE
Correct what to click to get appxmanifest designer

### DIFF
--- a/docs/windows/deployment/overview.md
+++ b/docs/windows/deployment/overview.md
@@ -26,7 +26,7 @@ The MSIX package is configured by the _Platforms\\Windows\\Package.appxmanifest_
 
 You can use the Manifest Designer feature of Visual Studio to visually edit the _Package.appxmanifest_ file, which affects how the app is displayed in the Microsoft Store and in Windows. You can also edit the _Package.appxmanifest_ file using the XML editor.
 
-- To use the Manifest Designer, find the **Solution Explorer** pane, then right-click **Platforms\\Windows\\Package.appxmanifest** > **Properties**.
+- To use the Manifest Designer, find the **Solution Explorer** pane, then right-click **Platforms\\Windows\\Package.appxmanifest** > **View Designer**.
 - To use the XML editor, find the **Solution Explorer** pane, then right-click **Platforms\\Windows\\Package.appxmanifest** > **View Code**.
 
 > [!IMPORTANT]


### PR DESCRIPTION
Original text said to click "Properties" from the context menu to open the designer, but that opens the Properties pane. Instead user needs to select "View Designer"